### PR TITLE
Rework nix Fixup

### DIFF
--- a/lib/modules/manager/nix/extract.spec.ts
+++ b/lib/modules/manager/nix/extract.spec.ts
@@ -1,5 +1,8 @@
+import { fs } from '../../../../test/util';
 import { GitRefsDatasource } from '../../datasource/git-refs';
 import { extractPackageFile } from '.';
+
+jest.mock('../../../util/fs');
 
 const flake1Lock = `{
   "nodes": {
@@ -389,12 +392,14 @@ const flake11Lock = `{
 }`;
 
 describe('modules/manager/nix/extract', () => {
-  it('returns null when no inputs', () => {
-    expect(extractPackageFile(flake1Lock, 'flake.lock')).toBeNull();
+  it('returns null when no inputs', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(flake1Lock);
+    expect(await extractPackageFile('', 'flake.nix')).toBeNull();
   });
 
-  it('returns nixpkgs input', () => {
-    expect(extractPackageFile(flake2Lock, 'flake.lock')?.deps).toEqual([
+  it('returns nixpkgs input', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(flake2Lock);
+    expect((await extractPackageFile('', 'flake.nix'))?.deps).toEqual([
       {
         depName: 'nixpkgs',
         currentDigest: '9f4128e00b0ae8ec65918efeba59db998750ead6',
@@ -406,8 +411,9 @@ describe('modules/manager/nix/extract', () => {
     ]);
   });
 
-  it('includes nixpkgs with no explicit ref', () => {
-    expect(extractPackageFile(flake3Lock, 'flake.lock')?.deps).toMatchObject([
+  it('includes nixpkgs with no explicit ref', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(flake3Lock);
+    expect((await extractPackageFile('', 'flake.nix'))?.deps).toMatchObject([
       {
         currentDigest: '612ee628421ba2c1abca4c99684862f76cb3b089',
         datasource: 'git-refs',
@@ -417,8 +423,9 @@ describe('modules/manager/nix/extract', () => {
     ]);
   });
 
-  it('includes patchelf from HEAD', () => {
-    expect(extractPackageFile(flake4Lock, 'flake.lock')?.deps).toMatchObject([
+  it('includes patchelf from HEAD', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(flake4Lock);
+    expect((await extractPackageFile('', 'flake.nix'))?.deps).toMatchObject([
       {
         currentDigest: 'a0f54334df36770b335c051e540ba40afcbf8378',
         datasource: 'git-refs',
@@ -428,8 +435,9 @@ describe('modules/manager/nix/extract', () => {
     ]);
   });
 
-  it('includes ijq from sourcehut without a flake', () => {
-    expect(extractPackageFile(flake5Lock, 'flake.lock')?.deps).toMatchObject([
+  it('includes ijq from sourcehut without a flake', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(flake5Lock);
+    expect((await extractPackageFile('', 'flake.nix'))?.deps).toMatchObject([
       {
         currentDigest: '88f0d9ae98942bf49cba302c42b2a0f6e05f9b58',
         datasource: 'git-refs',
@@ -439,23 +447,26 @@ describe('modules/manager/nix/extract', () => {
     ]);
   });
 
-  it('includes home-manager from gitlab', () => {
-    expect(extractPackageFile(flake6Lock, 'flake.lock')?.deps).toMatchObject([
+  it('includes home-manager from gitlab', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(flake6Lock);
+    expect((await extractPackageFile('', 'flake.nix'))?.deps).toMatchObject([
       {
         currentDigest: '65ae9c147349829d3df0222151f53f79821c5134',
-        datasource: 'git-refs',
+        datasource: 'git-refs123',
         depName: 'home-manager',
         packageName: 'https://gitlab.com/rycee/home-manager',
       },
     ]);
   });
 
-  it('test other version', () => {
-    expect(extractPackageFile(flake7Lock, 'flake.lock')).toBeNull();
+  it('test other version', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(flake7Lock);
+    expect(await extractPackageFile('', 'flake.nix')).toBeNull();
   });
 
-  it('includes nixpkgs with ref and shallow arguments', () => {
-    expect(extractPackageFile(flake8Lock, 'flake.lock')?.deps).toMatchObject([
+  it('includes nixpkgs with ref and shallow arguments', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(flake8Lock);
+    expect((await extractPackageFile('', 'flake.nix'))?.deps).toMatchObject([
       {
         currentDigest: '5633bcff0c6162b9e4b5f1264264611e950c8ec7',
         datasource: 'git-refs',
@@ -465,12 +476,14 @@ describe('modules/manager/nix/extract', () => {
     ]);
   });
 
-  it('includes nixpkgs but using indirect type that cannot be updated', () => {
-    expect(extractPackageFile(flake9Lock, 'flake.lock')).toBeNull();
+  it('includes nixpkgs but using indirect type that cannot be updated', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(flake9Lock);
+    expect(await extractPackageFile('', 'flake.nix')).toBeNull();
   });
 
-  it('includes flake from GitHub Enterprise', () => {
-    expect(extractPackageFile(flake10Lock, 'flake.lock')?.deps).toMatchObject([
+  it('includes flake from GitHub Enterprise', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(flake10Lock);
+    expect((await extractPackageFile('', 'flake.nix'))?.deps).toMatchObject([
       {
         currentDigest: '6bf2706348447df6f8b86b1c3e54f87b0afda84f',
         datasource: 'git-refs',
@@ -481,8 +494,9 @@ describe('modules/manager/nix/extract', () => {
     ]);
   });
 
-  it('includes flake with tarball type', () => {
-    expect(extractPackageFile(flake11Lock, 'flake.lock')?.deps).toMatchObject([
+  it('includes flake with tarball type', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(flake11Lock);
+    expect((await extractPackageFile('', 'flake.nix'))?.deps).toMatchObject([
       {
         currentDigest: 'c7e39452affcc0f89e023091524e38b3aaf109e9',
         datasource: 'git-refs',

--- a/lib/modules/manager/nix/extract.ts
+++ b/lib/modules/manager/nix/extract.ts
@@ -26,7 +26,7 @@ export async function extractPackageFile(
 
   const flakeLockParsed = NixFlakeLock.safeParse(lockContents);
   if (!flakeLockParsed.success) {
-    logger.error(
+    logger.debug(
       { packageLockFile, error: flakeLockParsed.error },
       `invalid flake.lock file`,
     );
@@ -44,9 +44,9 @@ export async function extractPackageFile(
     // skip all locked nodes which are not in the flake.nix and cannot be updated
     const rootInputs = flakeLock.nodes['root'].inputs;
     if (!rootInputs || !(depName in rootInputs)) {
-      logger.error(
+      logger.debug(
         { packageLockFile, error: flakeLockParsed.error },
-        `invalid flake.lock file because cannot find "root" node`,
+        `flake.lock file cannot find "root" node or reference to ${depName}`,
       );
       continue;
     }

--- a/lib/modules/manager/nix/extract.ts
+++ b/lib/modules/manager/nix/extract.ts
@@ -18,7 +18,7 @@ export async function extractPackageFile(
   packageFile: string,
 ): Promise<PackageFileContent | null> {
   const packageLockFile = getSiblingFileName(packageFile, 'flake.lock');
-  const lockContents = await readLocalFile(packageLockFile);
+  const lockContents = await readLocalFile(packageLockFile, 'utf8');
 
   logger.trace(`nix.extractPackageFile(${packageLockFile})`);
 


### PR DESCRIPTION
Fixes bug where `flake.nix` is being read, rather than `flake.lock` (see https://github.com/renovatebot/renovate/pull/31921#issuecomment-2520787904)

Example output PR: https://codeberg.org/testtrim/testtrim/pulls/100
